### PR TITLE
feat: make application insights' role name configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ export class AppInsightsTransport extends TransportStream {
     if (clientOptions && clientOptions.maxBatchIntervalMs) {
       this.client.config.maxBatchIntervalMs = clientOptions.maxBatchIntervalMs;
     }
+    if (customFields && customFields.serviceName) {
+      this.client.context.tags[ai.defaultClient.context.keys.cloudRole] = customFields.serviceName;
+    }
     this.customFields = customFields;
 
     this.handleUnhandledErrors();


### PR DESCRIPTION
To take full advantage of application insights' standard functionality it's necessary to set the role name properly. It defaults to web and in case one deploys different applications under one instrumentation id all metrics will be merged.
This change will fix this situation.

See documentations:
* https://github.com/microsoft/ApplicationInsights-node.js#multiple-roles-for-multi-component-applications
* https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-map?tabs=javascript#set-or-override-cloud-role-name